### PR TITLE
Fixed carousel slide animation

### DIFF
--- a/src/components/carousel/Carousel.vue
+++ b/src/components/carousel/Carousel.vue
@@ -238,7 +238,9 @@ export default {
         modeChange(trigger, value) {
             if (this.indicatorMode === trigger) {
                 this.$emit('input', value)
-                this.changeItem(value, false)
+                value < this.activeItem 
+                  ? this.changeItem(value, true)
+                  : this.changeItem(value, false)
             }
         },
         prev() {


### PR DESCRIPTION
Fixed the animation always sliding left regardless of position relative to the current slide.

<!-- Thank you for helping Buefy! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #2047

## Proposed Changes

-Add check logic when input event is emitted, the watcher does not change the behaviour of the animation (macOS 10.14.6).
